### PR TITLE
new tmp music page

### DIFF
--- a/lib/pages/tmp_music/cover_display.dart
+++ b/lib/pages/tmp_music/cover_display.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+
+Widget albumArt({required String cover, required VoidCallback onTap}) {
+  return InkWell(
+      onTap: onTap,
+      child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Container(
+              width: 180,
+              height: 180,
+              padding: const EdgeInsets.all(12),
+              margin: const EdgeInsets.symmetric(horizontal: 20, vertical: 20),
+              child: ClipRRect(
+                  borderRadius: BorderRadius.circular(20),
+                  child: Image.network(cover, fit: BoxFit.fill)),
+              decoration: BoxDecoration(
+                  color: Colors.grey.shade200,
+                  boxShadow: const [
+                    BoxShadow(
+                        color: Colors.grey,
+                        offset: Offset(12, 5),
+                        spreadRadius: 2.3,
+                        blurRadius: 20),
+                    BoxShadow(
+                        color: Colors.white,
+                        offset: Offset(-3, -4),
+                        spreadRadius: -2,
+                        blurRadius: 15)
+                  ],
+                  borderRadius: BorderRadius.circular(20)),
+            )
+          ]));
+}

--- a/lib/pages/tmp_music/media_display.dart
+++ b/lib/pages/tmp_music/media_display.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+Widget mediaList(
+    {required String title,
+    required String singer,
+    required String cover,
+    required VoidCallback onTap}) {
+  return InkWell(
+      onTap: onTap,
+      child: Container(
+          padding: const EdgeInsets.all(8),
+          child: Row(
+            children: [
+              Container(
+                height: 40.0,
+                width: 40.0,
+                decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(14.0),
+                    image: DecorationImage(image: NetworkImage(cover))),
+              ),
+              const SizedBox(
+                width: 10.0,
+              ),
+              Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+                Text(title,
+                    style: const TextStyle(fontSize: 12.0),
+                    textAlign: TextAlign.left),
+                const SizedBox(height: 5.0),
+                Text(singer,
+                    style:
+                        const TextStyle(color: Colors.black54, fontSize: 10.0),
+                    textAlign: TextAlign.left)
+              ])
+            ],
+          )));
+}

--- a/lib/pages/tmp_music/music_player.dart
+++ b/lib/pages/tmp_music/music_player.dart
@@ -1,0 +1,181 @@
+import 'package:audio_video_progress_bar/audio_video_progress_bar.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:soundspace/pages/tmp_music/cover_display.dart';
+import 'package:soundspace/pages/tmp_music/media_display.dart';
+import 'package:soundspace/pages/tmp_music/page_manager.dart';
+
+class MusicPlayer extends StatefulWidget {
+  const MusicPlayer({Key? key}) : super(key: key);
+
+  @override
+  State<MusicPlayer> createState() => _MusicPlayerState();
+}
+
+class _MusicPlayerState extends State<MusicPlayer> {
+  late final PageManager _pageManager;
+
+  @override
+  void initState() {
+    super.initState();
+    _pageManager = PageManager();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    double _height = MediaQuery.of(context).size.height; // page height
+    double _width = MediaQuery.of(context).size.width; // page height
+    return Column(children: <Widget>[
+      // Build image galley (horizontal)
+      Container(
+        height: _height / 3.2,
+        child: FutureBuilder<QuerySnapshot>(
+            future: FirebaseFirestore.instance.collection('ART').get(),
+            //convert documents into a list
+            builder: (context, snapshot) {
+              if (snapshot.hasData) {
+                final List<DocumentSnapshot> documents = snapshot.data!.docs;
+                //pass data to artListTile
+                return ListView.builder(
+                    itemCount: documents.length,
+                    scrollDirection: Axis.horizontal,
+                    itemBuilder: ((context, index) => albumArt(
+                        onTap: () {
+                          // Enlarge photos to full view when clicked
+                          Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                  fullscreenDialog: false,
+                                  builder: (BuildContext context) {
+                                    return Scaffold(
+                                        body: GestureDetector(
+                                      // add padding so images don't go to very edge
+                                      child: Padding(
+                                        padding: const EdgeInsets.all(14),
+                                        child: Center(
+                                            child: Hero(
+                                          // image animation when opening/closing
+                                          tag: 'imageHero',
+                                          child: ClipRRect(
+                                              // add slight border to images
+                                              borderRadius:
+                                                  BorderRadius.circular(6),
+                                              child: Image.network(
+                                                // show clicked image
+                                                documents[index]['url'],
+                                                fit: BoxFit.fill,
+                                              )),
+                                        )),
+                                      ),
+                                      onTap: () {
+                                        // return to art card
+                                        Navigator.pop(context);
+                                      },
+                                    ));
+                                  }));
+                        },
+                        cover: documents[index]['url'])));
+              } else {
+                return const Text("Error");
+              }
+            }),
+      ),
+
+      // Build Music Player
+      Container(
+        // Search Bar
+        margin: const EdgeInsets.fromLTRB(32, 24, 32, 24),
+        child: TextField(
+          controller: TextEditingController(),
+          decoration: InputDecoration(
+              prefixIcon: const Icon(Icons.search),
+              hintText: "Song Title",
+              border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(20),
+                  borderSide: const BorderSide(color: Colors.purple))),
+          onChanged: searchMusic, // filter function
+        ),
+      ),
+      Expanded(
+          // Music List
+          child: FutureBuilder<QuerySnapshot>(
+              future: FirebaseFirestore.instance
+                  .collection('MUSIC')
+                  .where('isVideo', isEqualTo: false)
+                  .get(),
+              //convert documents into a list
+              builder: (context, snapshot) {
+                if (snapshot.hasData) {
+                  final List<DocumentSnapshot> documents = snapshot.data!.docs;
+                  //pass data to customListTile
+                  return ListView.builder(
+                      itemCount: documents.length,
+                      itemBuilder: ((context, index) => mediaList(
+                          onTap: () {
+                            _pageManager.setSong(documents[index]['url']);
+                          },
+                          title: documents[index]['name'],
+                          singer: documents[index]['user'], //email for now
+                          cover: documents[index]['url'])));
+                } else {
+                  return const Text("Error");
+                }
+              })),
+      ValueListenableBuilder<ProgressBarState>(
+        // Music Controls (Slider, Pause/Play)
+        valueListenable: _pageManager.progressNotifier,
+        builder: (_, value, __) {
+          return ProgressBar(
+            progress: value.current,
+            buffered: value.buffered,
+            total: value.total,
+            onSeek: _pageManager.seek,
+          );
+        },
+      ),
+      ValueListenableBuilder<ButtonState>(
+        valueListenable: _pageManager.buttonNotifier,
+        builder: (_, value, __) {
+          switch (value) {
+            case ButtonState.loading:
+              return Container(
+                margin: const EdgeInsets.all(8.0),
+                width: 32.0,
+                height: 32.0,
+                child: const CircularProgressIndicator(),
+              );
+            case ButtonState.paused:
+              return IconButton(
+                icon: const Icon(Icons.play_arrow),
+                iconSize: 32.0,
+                onPressed: _pageManager.play,
+              );
+            case ButtonState.playing:
+              return IconButton(
+                icon: const Icon(Icons.pause),
+                iconSize: 32.0,
+                onPressed: _pageManager.pause,
+              );
+          }
+        },
+      )
+    ]);
+  }
+}
+
+/*
+  This function will filter the list based on the search words within
+  the bar - needs to convert all titles to lower case, filter based on
+  search criteria, and set the state. Below is a video that does something
+  similar but not with firebase (just a locally stored list):
+  https://www.youtube.com/watch?v=ZHdg2kfKmjI
+*/
+void searchMusic(String query) {}
+
+/*
+  Eventually we will need a function that can also filter the art/videos
+  being displayed to only show things associated with that song (right now
+  it's showing all uploaded art and no videos). Could possibly replace
+  the above searchMusic to just a searchFilter function that does everything
+  at once?
+*/

--- a/lib/pages/tmp_music/page_manager.dart
+++ b/lib/pages/tmp_music/page_manager.dart
@@ -1,0 +1,102 @@
+// Code came from: https://github.com/suragch/streaming_audio_flutter_demo/blob/master/lib/page_manager.dart
+// Only change was allowing url to be passed from firebase list (onTap)
+// Only works with mp3
+
+import 'package:flutter/material.dart';
+import 'package:just_audio/just_audio.dart';
+
+class PageManager {
+  final progressNotifier = ValueNotifier<ProgressBarState>(
+    ProgressBarState(
+      current: Duration.zero,
+      buffered: Duration.zero,
+      total: Duration.zero,
+    ),
+  );
+  final buttonNotifier = ValueNotifier<ButtonState>(ButtonState.paused);
+
+  late AudioPlayer _audioPlayer;
+  PageManager() {
+    _init();
+  }
+
+  void _init() async {
+    _audioPlayer = AudioPlayer();
+
+    _audioPlayer.playerStateStream.listen((playerState) {
+      final isPlaying = playerState.playing;
+      final processingState = playerState.processingState;
+      if (processingState == ProcessingState.loading ||
+          processingState == ProcessingState.buffering) {
+        buttonNotifier.value = ButtonState.loading;
+      } else if (!isPlaying) {
+        buttonNotifier.value = ButtonState.paused;
+      } else if (processingState != ProcessingState.completed) {
+        buttonNotifier.value = ButtonState.playing;
+      } else {
+        _audioPlayer.seek(Duration.zero);
+        _audioPlayer.pause();
+      }
+    });
+
+    _audioPlayer.positionStream.listen((position) {
+      final oldState = progressNotifier.value;
+      progressNotifier.value = ProgressBarState(
+        current: position,
+        buffered: oldState.buffered,
+        total: oldState.total,
+      );
+    });
+
+    _audioPlayer.bufferedPositionStream.listen((bufferedPosition) {
+      final oldState = progressNotifier.value;
+      progressNotifier.value = ProgressBarState(
+        current: oldState.current,
+        buffered: bufferedPosition,
+        total: oldState.total,
+      );
+    });
+
+    _audioPlayer.durationStream.listen((totalDuration) {
+      final oldState = progressNotifier.value;
+      progressNotifier.value = ProgressBarState(
+        current: oldState.current,
+        buffered: oldState.buffered,
+        total: totalDuration ?? Duration.zero,
+      );
+    });
+  }
+
+  void setSong(String url) {
+    _audioPlayer.setUrl(url);
+  }
+
+  void play() {
+    _audioPlayer.play();
+  }
+
+  void pause() {
+    _audioPlayer.pause();
+  }
+
+  void seek(Duration position) {
+    _audioPlayer.seek(position);
+  }
+
+  void dispose() {
+    _audioPlayer.dispose();
+  }
+}
+
+class ProgressBarState {
+  ProgressBarState({
+    required this.current,
+    required this.buffered,
+    required this.total,
+  });
+  final Duration current;
+  final Duration buffered;
+  final Duration total;
+}
+
+enum ButtonState { paused, playing, loading }

--- a/lib/pages/tmp_music/tmp_music.dart
+++ b/lib/pages/tmp_music/tmp_music.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:soundspace/constants/style.dart';
+import 'package:soundspace/pages/tmp_music/music_player.dart';
+
+class TmpMusicPage extends StatefulWidget {
+  const TmpMusicPage({Key? key}) : super(key: key);
+
+  @override
+  _MusicPageTMP createState() => _MusicPageTMP();
+}
+
+class _MusicPageTMP extends State<TmpMusicPage> {
+  @override
+  Widget build(BuildContext context) {
+    double _width = MediaQuery.of(context).size.width; // page width
+    double _height = MediaQuery.of(context).size.height; // page height
+    return Scaffold(
+        body: Container(
+            // background color of upload page
+            height: _height,
+            width: _width,
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                  // define gradient colors (top left to bottom right)
+                  begin: Alignment.topLeft,
+                  end: Alignment.bottomRight,
+                  colors: [Colors.purple.shade100, Colors.blue.shade100]),
+            ),
+            child: Padding(
+                padding: EdgeInsets.fromLTRB(_width / 10, _height / 13,
+                    _width / 10, _height / 13), // left, top, right, bottom
+                child: Container(
+                    // define container to hold music player
+                    height: MediaQuery.of(context).size.height * 0.7,
+                    alignment: Alignment.center,
+                    decoration: BoxDecoration(
+                        gradient: LinearGradient(
+                            begin: Alignment.topCenter,
+                            end: Alignment.bottomCenter,
+                            colors: [
+                              Colors.grey.shade50,
+                              Colors.grey.shade200
+                            ]),
+                        boxShadow: [
+                          BoxShadow(
+                              offset: const Offset(0, 6),
+                              color: lightGrey.withOpacity(0.1),
+                              blurRadius: 12)
+                        ],
+                        borderRadius: BorderRadius.circular(8)),
+                    child: Padding(
+                        // add padding to each side
+                        padding: EdgeInsets.fromLTRB(_width / 16, _height / 24,
+                            _width / 16, _height / 24),
+                        child: MusicPlayer())))));
+  }
+}

--- a/lib/routing/router.dart
+++ b/lib/routing/router.dart
@@ -3,6 +3,7 @@ import 'package:soundspace/pages/account/account.dart';
 import 'package:soundspace/pages/approval/approval.dart';
 import 'package:soundspace/pages/music/music.dart';
 import 'package:soundspace/pages/home/home.dart';
+import 'package:soundspace/pages/tmp_music/tmp_music.dart';
 import 'package:soundspace/pages/trending/trending.dart';
 import 'package:soundspace/pages/upload/upload.dart';
 import 'package:soundspace/routing/routes.dart';
@@ -18,7 +19,7 @@ Route<dynamic> generateRoute(RouteSettings settings) {
     case UploadPageRoute:
       return _getPageRoute(UploadPage());
     case MusicPageRoute:
-      return _getPageRoute(MusicPage());
+      return _getPageRoute(TmpMusicPage()); // TMP MUSIC PAGE BEING USED
     case AccountPageRoute:
       return _getPageRoute(AccountPage());
     case ApprovalPageRoute:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -36,6 +36,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.8.2"
+  audio_session:
+    dependency: transitive
+    description:
+      name: audio_session
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.6+1"
+  audio_video_progress_bar:
+    dependency: "direct main"
+    description:
+      name: audio_video_progress_bar
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.10.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -296,6 +310,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.6.3"
+  just_audio:
+    dependency: "direct main"
+    description:
+      name: just_audio
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.9.20"
+  just_audio_platform_interface:
+    dependency: transitive
+    description:
+      name: just_audio_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.1.0"
+  just_audio_web:
+    dependency: transitive
+    description:
+      name: just_audio_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.4.7"
   lints:
     dependency: transitive
     description:
@@ -464,6 +499,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.0.4"
+  rxdart:
+    dependency: transitive
+    description:
+      name: rxdart
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.27.3"
   shelf:
     dependency: transitive
     description:
@@ -630,6 +672,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.0"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.6"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,8 @@ dependencies:
   animated_text_kit: ^4.2.1
   dropdown_button2: ^1.2.2
   responsive_flutter: ^0.0.4
+  just_audio: ^0.9.20
+  audio_video_progress_bar: ^0.10.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
New music page (made a new folder, left the original music page how it was):
- Now displays art in a horizontal scrollable gallery.
- Below that is a search bar to search through list of available songs (not functional yet, need help filtering firebase query).
- Then there is a list of all available songs to play.
- Bottom of music player has a progress bar that is movable for song position, along with a pause/play button -> will play a song if clicked inside the list (only 2 valid mp3 files right now in the list).
- Changed the page in the route.dart (change back to MusicPage() to see the one Evan is working on).

**Note**: right now it is set up to work with MP3's (I got the code from someone online, so no worries if we want to use the YouTube player as our music player - this didn't take long and can easily be switched out for it). I'll make some issues on what will need to be updated in terms of filtering that would be mostly backend changes, I wasn't sure how to do any of it really.