### PR TITLE
Pending approval removed

### DIFF
--- a/lib/pages/approval/approval.dart
+++ b/lib/pages/approval/approval.dart
@@ -64,7 +64,7 @@ class ApprovalPage extends StatelessWidget {
                                 ApplicationLoginState.loggedIn) ...[
                               //form to submit artwork for approval
                               const ApprovalRequestForm(),
-                              //list of pending approvals with option to approve or reject
+                              //list of approvals with option to reject (remove)
                               const ViewApprovals(),
                             ] else ...[
                               //user is logged out, prompt redirect to account page

--- a/lib/pages/approval/approval_request_form.dart
+++ b/lib/pages/approval/approval_request_form.dart
@@ -24,7 +24,7 @@ class _ApprovalRequestFormState extends State<ApprovalRequestForm> {
   final _musicNameController = TextEditingController();
   final _artNameController = TextEditingController();
 
-  //verify art and music names and create pending approval
+  //verify art and music names and create approval
   Future<void> createApprovalInstance(String artName, String musicName) async {
     //find the art document with matching name
     bool validUpload = true;

--- a/lib/pages/approval/view_approvals.dart
+++ b/lib/pages/approval/view_approvals.dart
@@ -14,6 +14,7 @@ class _ViewApprovalsState extends State<ViewApprovals> {
       FirebaseFirestore.instance.collection('MUSIC');
   CollectionReference artCollection =
       FirebaseFirestore.instance.collection('ART');
+
   /*  For future consideration:
    *  Maybe add another list of rejected approvals to MUSIC
    *  That way a user can't spam their art for approval
@@ -81,9 +82,9 @@ class _ViewApprovalsState extends State<ViewApprovals> {
           //turn a collection of documents into a dictionary and iterate through
           children: snapshot.data!.docs.map((DocumentSnapshot document) {
             Map<String, dynamic> data = document.data() as Map<String, dynamic>;
-            //check if the document has pending approvals
+            //check if the document has approvals
             if (data['approvals'].isNotEmpty) {
-              //second StreamBuilder - tracks artworks - filters by pending approvals
+              //second StreamBuilder - tracks artworks - filters by approvals
               return StreamBuilder(
                 stream: _artStream,
                 builder: (BuildContext context,
@@ -101,17 +102,12 @@ class _ViewApprovalsState extends State<ViewApprovals> {
                       style: const TextStyle(fontWeight: FontWeight.bold)));
                   artSnapshot.data!.docs.forEach((element) {
                     if (data['approvals'].contains(element.id)) {
-                      //Add pending artwork and approve/reject buttons in a Row
+                      //Add artwork and reject button in a Row
                       arts.add(Row(
                           mainAxisAlignment: MainAxisAlignment.center,
                           crossAxisAlignment: CrossAxisAlignment.center,
                           children: [
                             Text(element.get('name')),
-                            /*TextButton(
-                                child: const Text('Approve'),
-                                onPressed: () {
-                                  approveArt(data['name'], element.id);
-                                }),*/
                             TextButton(
                                 child: const Text('Reject'),
                                 onPressed: () {
@@ -129,7 +125,7 @@ class _ViewApprovalsState extends State<ViewApprovals> {
                 },
               );
             } else {
-              //document has no pending approvals, but we still need a widget
+              //document has no approvals, but we still need a widget
               return const Text('');
             }
           }).toList(),

--- a/lib/pages/upload/music_handler.dart
+++ b/lib/pages/upload/music_handler.dart
@@ -25,7 +25,6 @@ class _MusicHandlerState extends State<MusicHandler> {
     var user = FirebaseAuth.instance.currentUser;
     //list to be populated w/ IDs of approved art
     List approvals = [];
-    List pendingApprovals = [];
     if (user == null) {
       //this *should* never run because of the if/else in upload.dart
       print("ERROR: music_handler upload - User should not be null");
@@ -37,7 +36,6 @@ class _MusicHandlerState extends State<MusicHandler> {
           'url': url,
           'user': user!.email,
           'approvals': approvals,
-          'pendingApprovals': pendingApprovals
         })
         // .then is for any console output mostly for testing
         .then((value) => print("Added Music( name: $name , url: $url )"))


### PR DESCRIPTION
Removed the "pending" stage from the approval process and all its related dependencies. The music upload no longer adds an array of pending objects, the approval submission immediately approves the work and updates both related arrays, and the "view approvals" section has been changed to show approved (not pending) art and have an option to remove instead of approving or rejecting.
This should make the approval process more streamlined, which is good because all our video player stuff depends on it.